### PR TITLE
fix includes

### DIFF
--- a/include/createEnemy.h
+++ b/include/createEnemy.h
@@ -1,1 +1,3 @@
+#include "entity.h"
+
 Entity* CreateEnemy(u8, u8);

--- a/include/createEnemy.h
+++ b/include/createEnemy.h
@@ -1,3 +1,8 @@
+#ifndef GUARD_CREATEENEMY_H
+#define GUARD_CREATEENEMY_H
+
 #include "entity.h"
 
 Entity* CreateEnemy(u8, u8);
+
+#endif // GUARD_CREATEENEMY_H

--- a/include/greatFairy.h
+++ b/include/greatFairy.h
@@ -1,6 +1,8 @@
 #ifndef GREATFAIRY_H
 #define GREATFAIRY_H
 
+#include "screen.h"
+
 extern u32 __modsi3(u32, u32);
 extern void InitializeAnimation(Entity*, u32);
 extern void GreatFairy_InitializeAnimation(Entity*);

--- a/include/item.h
+++ b/include/item.h
@@ -5,38 +5,38 @@
 #include "entity.h"
 #include "player.h"
 
-void extern DebugItem(ItemBehavior*, u32);
-void extern Sword(ItemBehavior*, u32);
-void extern Sword(ItemBehavior*, u32);
-void extern Sword(ItemBehavior*, u32);
-void extern Sword(ItemBehavior*, u32);
-void extern Sword(ItemBehavior*, u32);
-void extern Sword(ItemBehavior*, u32);
-void extern Bomb(ItemBehavior*, u32);
-void extern Bomb(ItemBehavior*, u32);
-void extern Bow(ItemBehavior*, u32);
-void extern Bow(ItemBehavior*, u32);
-void extern sub_08075D14(ItemBehavior*, u32);
-void extern sub_08075D14(ItemBehavior*, u32);
-void extern Shield(ItemBehavior*, u32);
-void extern Shield(ItemBehavior*, u32);
-void extern Lantern(ItemBehavior*, u32);
-void extern Lantern(ItemBehavior*, u32);
-void extern GustJar(ItemBehavior*, u32);
-void extern PacciCane(ItemBehavior*, u32);
-void extern MoleMitts(ItemBehavior*, u32);
-void extern RocsCape(ItemBehavior*, u32);
-void extern sub_08076800(ItemBehavior*, u32);
-void extern DebugItem(ItemBehavior*, u32);
-void Ocarina(ItemBehavior*, u32);
-void extern DebugItem(ItemBehavior*, u32);
-void extern DebugItem(ItemBehavior*, u32);
-void extern DebugItem(ItemBehavior*, u32);
-void extern TryPickupObject(ItemBehavior*, u32);
-void extern JarEmpty(ItemBehavior*, u32);
-void extern JarEmpty(ItemBehavior*, u32);
-void extern JarEmpty(ItemBehavior*, u32);
-void extern JarEmpty(ItemBehavior*, u32);
+extern void DebugItem(ItemBehavior*, u32);
+extern void Sword(ItemBehavior*, u32);
+extern void Sword(ItemBehavior*, u32);
+extern void Sword(ItemBehavior*, u32);
+extern void Sword(ItemBehavior*, u32);
+extern void Sword(ItemBehavior*, u32);
+extern void Sword(ItemBehavior*, u32);
+extern void Bomb(ItemBehavior*, u32);
+extern void Bomb(ItemBehavior*, u32);
+extern void Bow(ItemBehavior*, u32);
+extern void Bow(ItemBehavior*, u32);
+extern void sub_08075D14(ItemBehavior*, u32);
+extern void sub_08075D14(ItemBehavior*, u32);
+extern void Shield(ItemBehavior*, u32);
+extern void Shield(ItemBehavior*, u32);
+extern void Lantern(ItemBehavior*, u32);
+extern void Lantern(ItemBehavior*, u32);
+extern void GustJar(ItemBehavior*, u32);
+extern void PacciCane(ItemBehavior*, u32);
+extern void MoleMitts(ItemBehavior*, u32);
+extern void RocsCape(ItemBehavior*, u32);
+extern void sub_08076800(ItemBehavior*, u32);
+extern void DebugItem(ItemBehavior*, u32);
+extern void Ocarina(ItemBehavior*, u32);
+extern void DebugItem(ItemBehavior*, u32);
+extern void DebugItem(ItemBehavior*, u32);
+extern void DebugItem(ItemBehavior*, u32);
+extern void TryPickupObject(ItemBehavior*, u32);
+extern void JarEmpty(ItemBehavior*, u32);
+extern void JarEmpty(ItemBehavior*, u32);
+extern void JarEmpty(ItemBehavior*, u32);
+extern void JarEmpty(ItemBehavior*, u32);
 
 /* On hold until naming conflicts are resolved */
 /*

--- a/include/textbox.h
+++ b/include/textbox.h
@@ -23,5 +23,5 @@ extern TextBox gTextBox;
 
 void TextboxNoOverlap(u32 index, Entity* ent);
 
-void extern TextboxNoOverlapFollow(u32 index);
+extern void TextboxNoOverlapFollow(u32 index);
 #endif


### PR DESCRIPTION
Fixed some include files to work on their own and move extern to the start of the line.

Motivation was to load the header files into ghidra.

Attached an example types archive.
[tmc.zip](https://github.com/zeldaret/tmc/files/5742570/tmc.zip)

