### PR TITLE
Fix Linker Warnings

### DIFF
--- a/include/coord.h
+++ b/include/coord.h
@@ -15,7 +15,7 @@ void sub_0806FA90(Entity*, Entity*, s32, s32);
 void ResolveEntityOnTop(Entity*, Entity*);
 void sub_0806FAD8(Entity*, Entity*);
 
-const s16 gSineTable[64];
-const s16 gCosineTable[256];
+extern const s16 gSineTable[64];
+extern const s16 gCosineTable[256];
 
 #endif

--- a/include/manager.h
+++ b/include/manager.h
@@ -191,6 +191,6 @@ extern void sub_0805DE38(Entity*);
 extern void sub_0805E0A8(Entity*);
 extern void sub_0805E0FC();
 
-void (*const gManagerFunctions[58])();
+extern void (*const gManagerFunctions[58])();
 
 #endif

--- a/include/npc.h
+++ b/include/npc.h
@@ -168,6 +168,6 @@ extern void NPC58_Head(Entity*);
 
 extern u32 UpdateFuseInteraction(Entity*);
 
-void (*const gNPCFunctions[128][3])(Entity*);
+extern void (*const gNPCFunctions[128][3])(Entity*);
 
 #endif

--- a/include/object.h
+++ b/include/object.h
@@ -396,6 +396,6 @@ extern void ObjectBF(Entity*);
 extern void EnemyItem(Entity*);
 extern void ObjectC1(Entity*);
 
-void (*const gObjectFunctions[194])(Entity*);
+extern void (*const gObjectFunctions[194])(Entity*);
 
 #endif


### PR DESCRIPTION
The linker warns about variable alignment because some variables are not declared extern in their header as they should be