### PR TITLE
Fix Debug build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ endif
 
 #$(C_BUILDDIR)/need_interworking_file_name.o: CFLAGS += -mthumb-interwork
 $(C_BUILDDIR)/arm_proxy.o: CFLAGS += -mthumb-interwork
-$(C_BUILDDIR)/gba/m4a.o: CFLAGS += -mthumb-interwork
+$(C_BUILDDIR)/gba/m4a.o: CFLAGS = -O2 -mthumb-interwork -Wimplicit -Wparentheses -Werror -Wno-multichar
 $(C_BUILDDIR)/eeprom.o: CFLAGS = -O1 -mthumb-interwork -Wimplicit -Wparentheses -Werror -Wno-multichar
 
 C_SRCS := $(wildcard $(C_SUBDIR)/*.c $(C_SUBDIR)/*/*.c)


### PR DESCRIPTION
m4a.c does not link after being compiled with -g.
This is just a quick fix that manually overrides the CFLAGS for this file.
In the future some better handling of the debug flags should be implemented.