### PR TITLE
Fix format.sh

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -24,7 +24,7 @@ clang-format ${FORMAT_OPTS} src/**/*.c
 clang-format ${FORMAT_OPTS} include/**/*.h
 echo "Running clang-tidy..."
 clang-tidy ${TIDY_OPTS} src/**/*.c -- ${COMPILER_OPTS} &> /dev/null
-clang-format ${FORMAT_OPTS} include/**/*.h
+clang-tidy ${TIDY_OPTS} include/**/*.h -- ${COMPILER_OPTS} &> /dev/null
 echo "Adding missing final new lines..."
 find src/ -type f -name "*.c" -exec sed -i -e '$a\' {} \;
 echo "Done formatting all files."

--- a/include/createObject.h
+++ b/include/createObject.h
@@ -1,6 +1,8 @@
 #ifndef CREATEOBJECT_H
 #define CREATEOBJECT_H
 
+#include "entity.h"
+
 // maybe a dedicated (create)Effect.h/c
 void CreateDust(Entity* parent);
 void CreateDustSmall(Entity* parent);

--- a/include/cutscene.h
+++ b/include/cutscene.h
@@ -8,7 +8,7 @@ typedef struct {
     u8 textIndex;
     u8 filler[11];
     u16 pauseTime;
-    u8 filler[2];
+    u8 filler2[2];
     s32 targetX;
     s32 targetY;
 } CutsceneBehavior;

--- a/include/enemy.h
+++ b/include/enemy.h
@@ -1,5 +1,5 @@
 #ifndef ENEMY_H
-#define EMEMY_H
+#define ENEMY_H
 
 #include "global.h"
 #include "entity.h"

--- a/include/game.h
+++ b/include/game.h
@@ -1,6 +1,8 @@
 #ifndef GAME_H
 #define GAME_H
 
+#include "gba/types.h"
+
 u32 CheckIsDungeon(void);
 
 #endif // GAME_H

--- a/include/gba/eeprom.h
+++ b/include/gba/eeprom.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_GBA_EEPROM
 #define GUARD_GBA_EEPROM
 
+#include "types.h"
+
 // error codes
 #define EEPROM_OUT_OF_RANGE 0x80ff
 #define EEPROM_COMPARE_FAILED 0x8000

--- a/include/gba/flash_internal.h
+++ b/include/gba/flash_internal.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_GBA_FLASH_INTERNAL_H
 #define GUARD_GBA_FLASH_INTERNAL_H
 
+#include "types.h"
+
 #define FLASH_BASE ((u8*)0xE000000)
 
 #define FLASH_WRITE(addr, data) ((*(vu8*)(FLASH_BASE + (addr))) = (data))

--- a/include/gba/multi_boot.h
+++ b/include/gba/multi_boot.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_GBA_MULTI_BOOT_H
 #define GUARD_GBA_MULTI_BOOT_H
 
+#include "types.h"
+
 #define MULTIBOOT_NCHILD 3              // Maximum number of slaves
 #define MULTIBOOT_HEADER_SIZE 0xc0      // Header size
 #define MULTIBOOT_SEND_SIZE_MIN 0x100   // Minimum transmission size

--- a/include/gba/syscall.h
+++ b/include/gba/syscall.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_GBA_SYSCALL_H
 #define GUARD_GBA_SYSCALL_H
 
+#include "types.h"
+
 #define RESET_EWRAM 0x01
 #define RESET_IWRAM 0x02
 #define RESET_PALETTE 0x04

--- a/include/greatFairy.h
+++ b/include/greatFairy.h
@@ -1,6 +1,7 @@
 #ifndef GREATFAIRY_H
 #define GREATFAIRY_H
 
+#include "entity.h"
 #include "screen.h"
 
 void GreatFairy_InitializeAnimation(Entity*);

--- a/include/main.h
+++ b/include/main.h
@@ -1,6 +1,8 @@
 #ifndef MAIN_H
 #define MAIN_H
 
+#include "global.h"
+
 typedef struct { // 0x03001000
     u8 field_0x0;
     u8 field_0x1;

--- a/include/random.h
+++ b/include/random.h
@@ -1,6 +1,8 @@
 #ifndef RANDOM_H
 #define RANDOM_H
 
+#include "gba/types.h"
+
 extern u32 Random(void);
 
 extern u32 gRand;

--- a/include/script.h
+++ b/include/script.h
@@ -1,7 +1,7 @@
 #ifndef SCRIPT_H
 #define SCRIPT_H
 
-#include "global.h"
+#include "entity.h"
 
 typedef struct ScriptExecutionContext {
     u16* scriptInstructionPointer;

--- a/src/enemy/moldorm.c
+++ b/src/enemy/moldorm.c
@@ -141,6 +141,9 @@ void sub_08022DE8(Entity* this) {
     }
 }
 
+// this definition is only here, so clang-tidy does not mess gUnk_080CBBBC up.
+extern void sub_08022E40(Entity* this);
+
 ASM_FUNC("asm/non_matching/moldorm/sub_08022E40.inc", void sub_08022E40(Entity* this))
 
 ASM_FUNC("asm/non_matching/moldorm/sub_08022EAC.inc", void sub_08022EAC(Entity* this))


### PR DESCRIPTION
Run `clang-tidy` on header files as well.
Add workaround to prevent `clang-tidy` from messing up `moldorm.c`.