### PR TITLE
Update progress script with new csv format, text mode, etc.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,9 @@ pipeline {
             }
             steps {
                 sh 'mkdir reports'
-                sh 'python3 progress.py csv >> reports/progress_tmc.csv'
-                sh 'python3 progress.py csv -m >> reports/progress_tmc_matching.csv'
+                sh 'python3 progress.py csv >> reports/progress-tmc-nonmatching.csv'
+                sh 'python3 progress.py csv -m >> reports/progress-tmc-matching.csv'
+                sh 'python3 progress.py shield-json > reports/progress-tmc-shield.json'
                 stash includes: 'reports/*', name: 'reports'
             }
         }
@@ -40,8 +41,9 @@ pipeline {
             }
             steps {
                 unstash 'reports'
-                sh 'cat reports/progress_tmc.csv >> /var/www/html/reports/progress_tmc.csv'
-                sh 'cat reports/progress_tmc_matching.csv >> /var/www/html/reports/progress_tmc_matching.csv'
+                sh 'cat reports/progress-tmc-nonmatching.csv >> /var/www/zelda64.dev/assets/csv/progress-tmc-nonmatching.csv'
+                sh 'cat reports/progress-tmc-matching.csv >> /var/www/zelda64.dev/assets/csv/progress-tmc-matching.csv'
+                sh 'cat reports/progress-tmc-shield.json > /var/www/zelda64.dev/assets/csv/progress-tmc-shield.json'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,8 @@ pipeline {
             }
             steps {
                 sh 'mkdir reports'
-                sh 'python3 progress.py >> reports/progress_tmc.csv'
-                sh 'python3 progress.py -m >> reports/progress_tmc_matching.csv'
+                sh 'python3 progress.py csv >> reports/progress_tmc.csv'
+                sh 'python3 progress.py csv -m >> reports/progress_tmc_matching.csv'
                 stash includes: 'reports/*', name: 'reports'
             }
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # The Legend of Zelda: The Minish Cap
 
-**Progress:**  [⬛⬛⬛⬛⬛⬛⬛⬛⬛⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜] 45%
+
+[![Build Status][jenkins-badge]][jenkins] [![Decompilation Progress][progress-badge]][progress] [![Contributors][contributors-badge]][contributors] [![Discord Channel][discord-badge]][discord]
+
+[jenkins]: https://jenkins.deco.mp/job/TMC/job/master
+[jenkins-badge]: https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.deco.mp%2Fjob%2FTMC%2Fjob%2Fmaster
+
+[progress]: https://zelda64.dev/games/tmc
+[progress-badge]: https://img.shields.io/endpoint?url=https://zelda64.dev/assets/csv/progress-mm-shield.json
+
+[contributors]: https://github.com/zeldaret/tmc/graphs/contributors
+[contributors-badge]: https://img.shields.io/github/contributors/zeldaret/tmc
+
+[discord]: https://discord.zelda64.dev
+[discord-badge]: https://img.shields.io/discord/688807550715560050?color=%237289DA&logo=discord&logoColor=%23FFFFFF
 
 ```diff
 - WARNING! -

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [jenkins-badge]: https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.deco.mp%2Fjob%2FTMC%2Fjob%2Fmaster
 
 [progress]: https://zelda64.dev/games/tmc
-[progress-badge]: https://img.shields.io/endpoint?url=https://zelda64.dev/assets/csv/progress-mm-shield.json
+[progress-badge]: https://img.shields.io/endpoint?url=https://zelda64.dev/assets/csv/progress-tmc-shield.json
 
 [contributors]: https://github.com/zeldaret/tmc/graphs/contributors
 [contributors-badge]: https://img.shields.io/github/contributors/zeldaret/tmc


### PR DESCRIPTION
- Updated `progress.py` to the csv format the website will use, namely `csv_version, date, git_hash, src_code, total_code, src_data, total_data`, for now.
- Added text mode, although it is a little bare with no subcategorisation, it would be easy to incorporate that should the project implement it at some point.
- Also added a shield.json mode that can be used to display in the README.md if desired.
- Also updated the Jenkinsfile to take into account the new input format.

Most of these features were implemented based on the OoT/MM progress scripts.

*This cannot be merged until the new website is ready and the historic data in the csv is updated to the new format.*

@Henny022p has kindly offered to reconstruct the csv once we are all agreed on the format to use, if we wish to add additional columns to track e.g. engine vs entity. There has also been some discussion of splitting data up by asset type, but I'm not sure how practical that is at this point.