### PR TITLE
format.sh: Only touch file if new line is needed

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -27,6 +27,6 @@ clang-tidy ${TIDY_OPTS} src/**/*.c -- ${COMPILER_OPTS} &> /dev/null
 clang-tidy ${TIDY_OPTS} include/**/*.h -- ${COMPILER_OPTS} &> /dev/null
 echo "Adding missing final new lines..."
 
-# only run sed if no line at the end of file so we don't unnecessarily touch the file.
+# only run sed if no new line at the end of file so we don't unnecessarily touch the file.
 find src/ -type f -name "*.c" -exec bash -c 'if [[ -n  "$(tail -c 1 {})" ]]; then sed -i -e '"'"'$a\'"'"' {}; fi' \;
 echo "Done formatting all files."

--- a/format.sh
+++ b/format.sh
@@ -26,5 +26,7 @@ echo "Running clang-tidy..."
 clang-tidy ${TIDY_OPTS} src/**/*.c -- ${COMPILER_OPTS} &> /dev/null
 clang-tidy ${TIDY_OPTS} include/**/*.h -- ${COMPILER_OPTS} &> /dev/null
 echo "Adding missing final new lines..."
-find src/ -type f -name "*.c" -exec sed -i -e '$a\' {} \;
+
+# only run sed if no line at the end of file so we don't unnecessarily touch the file.
+find src/ -type f -name "*.c" -exec bash -c 'if [[ -n  "$(tail -c 1 {})" ]]; then sed -i -e '"'"'$a\'"'"' {}; fi' \;
 echo "Done formatting all files."


### PR DESCRIPTION
format.sh uses sed on all files to add new lines, which touches them all, meaning a need to recompile everything.
This change looks at the last character and only runs sed if it is not a new line.