### PR TITLE
Initial version of enum extractor script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,15 +57,18 @@ DATA_ASM_SUBDIR = data
 SONG_SUBDIR = sound/songs
 MID_SUBDIR = sound/songs/midi
 ASSET_SUBDIR = assets
+ENUM_INCLUDE_SUBDIR = enum_include
 
 C_BUILDDIR = $(OBJ_DIR)/$(C_SUBDIR)
 ASM_BUILDDIR = $(OBJ_DIR)/$(ASM_SUBDIR)
+ASM_ENUM_INCLUDE_DIR = $(ASM_BUILDDIR)/$(ENUM_INCLUDE_SUBDIR)
 DATA_ASM_BUILDDIR = $(OBJ_DIR)/$(DATA_ASM_SUBDIR)
 SONG_BUILDDIR = $(OBJ_DIR)/$(SONG_SUBDIR)
 MID_BUILDDIR = $(OBJ_DIR)/$(MID_SUBDIR)
 ASSET_BUILDDIR = $(OBJ_DIR)/$(ASSET_SUBDIR)
+PREPROC_INC_PATHS = $(ASSET_BUILDDIR) $(ASM_ENUM_INCLUDE_DIR)
 
-ASFLAGS := -mcpu=arm7tdmi --defsym $(GAME_VERSION)=1 --defsym REVISION=$(REVISION) --defsym $(GAME_LANGUAGE)=1 -I $(ASSET_SUBDIR) -I $(ASSET_BUILDDIR)
+ASFLAGS := -mcpu=arm7tdmi --defsym $(GAME_VERSION)=1 --defsym REVISION=$(REVISION) --defsym $(GAME_LANGUAGE)=1 -I $(ASSET_SUBDIR) -I $(ASSET_BUILDDIR) -I $(ASM_ENUM_INCLUDE_DIR)
 
 CC1             := tools/agbcc/bin/agbcc
 override CFLAGS += -O2 -Wimplicit -Wparentheses -Werror -Wno-multichar -g3
@@ -90,6 +93,7 @@ SCANINC := tools/bin/scaninc
 PREPROC := tools/bin/preproc
 FIX := tools/bin/gbafix
 ASSET_PROCESSOR := tools/bin/asset_processor
+ENUM_PROCESSOR := tools/extract_include_enum.py
 
 ASSET_CONFIGS = assets/assets.json assets/gfx.json assets/map.json assets/samples.json assets/sounds.json
 TRANSLATIONS = translations/USA.bin translations/English.bin translations/French.bin translations/German.bin translations/Spanish.bin translations/Italian.bin
@@ -142,10 +146,13 @@ SONG_OBJS := $(patsubst $(SONG_SUBDIR)/%.s,$(SONG_BUILDDIR)/%.o,$(SONG_SRCS))
 MID_SRCS := $(wildcard $(MID_SUBDIR)/*.mid)
 MID_OBJS := $(patsubst $(MID_SUBDIR)/%.mid,$(MID_BUILDDIR)/%.o,$(MID_SRCS))
 
+ENUM_ASM_SRCS := $(wildcard include/*.h)
+ENUM_ASM_HEADERS := $(patsubst include/%.h,$(ASM_ENUM_INCLUDE_DIR)/%.inc,$(ENUM_ASM_SRCS))
+
 OBJS := $(C_OBJS) $(ASM_OBJS) $(DATA_ASM_OBJS) $(SONG_OBJS) $(MID_OBJS)
 OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 
-SUBDIRS  := $(sort $(dir $(OBJS)))
+SUBDIRS  := $(sort $(dir $(OBJS) $(ENUM_ASM_HEADERS)))
 
 $(shell mkdir -p $(SUBDIRS))
 
@@ -253,16 +260,19 @@ $(ASM_BUILDDIR)/%.o: asm_dep = $(shell $(SCANINC) -I . $(ASM_SUBDIR)/$*.s)
 endif
 
 $(ASM_BUILDDIR)/%.o: $(ASM_SUBDIR)/%.s $$(asm_dep)
-	$(PREPROC) $(BUILD_NAME) $< | $(AS) $(ASFLAGS) -o $@
+	$(PREPROC) $(BUILD_NAME) $< -- $(PREPROC_INC_PATHS) | $(AS) $(ASFLAGS) -o $@
+
+$(ASM_ENUM_INCLUDE_DIR)/%.inc: include/%.h
+	$(ENUM_PROCESSOR) $< $(CC) "-D__attribute__(x)=" "-E" "-nostdinc" "-Itools/agbcc" "-Itools/agbcc/include" "-iquote include" > $@
 
 ifeq ($(NODEP),1)
 $(DATA_ASM_BUILDDIR)/%.o: data_dep :=
 else
-$(DATA_ASM_BUILDDIR)/%.o: data_dep = $(shell $(SCANINC) -I . -I $(ASSET_SUBDIR) -I $(ASSET_BUILDDIR) $(DATA_ASM_SUBDIR)/$*.s)
+$(DATA_ASM_BUILDDIR)/%.o: data_dep = $(shell $(SCANINC) -I . -I $(ASSET_SUBDIR) -I $(ASSET_BUILDDIR) -I $(ASM_ENUM_INCLUDE_DIR) $(DATA_ASM_SUBDIR)/$*.s)
 endif
 
-$(DATA_ASM_BUILDDIR)/%.o: $(DATA_ASM_SUBDIR)/%.s $$(data_dep)
-	$(PREPROC) $(BUILD_NAME) $< charmap.txt | $(CPP) -I include -nostdinc -undef -Wno-unicode - | $(AS) $(ASFLAGS) -o $@
+$(DATA_ASM_BUILDDIR)/%.o: $(DATA_ASM_SUBDIR)/%.s $$(data_dep) $(ENUM_ASM_HEADERS)
+	$(PREPROC) $(BUILD_NAME) $< charmap.txt -- $(PREPROC_INC_PATHS) | $(CPP) -I include -nostdinc -undef -Wno-unicode - | $(AS) $(ASFLAGS) -o $@
 
 $(SONG_BUILDDIR)/%.o: $(SONG_SUBDIR)/%.s
 	$(AS) $(ASFLAGS) -I sound -o $@ $<

--- a/asm/macros/scripts.inc
+++ b/asm/macros/scripts.inc
@@ -489,6 +489,12 @@
 	.2byte \s
 .endm
 
+.macro MessageNoOverlap2 a:req, b:req
+	.2byte 0x085b
+	.byte \b
+	.byte \a
+.endm
+
 .macro MessageFromTargetPos a:req, b:req
 	.2byte 0x0c5c
 	.2byte \a

--- a/data/scripts.s
+++ b/data/scripts.s
@@ -3,6 +3,9 @@
 
 	.include "asm/macros/scripts.inc"
 
+	.include "flags.inc"
+	.include "message.inc"
+
 	.syntax unified
 	.text
 

--- a/data/scripts/hyruleTown/script_Din.inc
+++ b/data/scripts/hyruleTown/script_Din.inc
@@ -5,7 +5,7 @@ SCRIPT_START script_Din
 	SetAnimationState 0x0004
 	DoPostScriptAction 0x0001
 	DoPostScriptAction 0x000a
-	CheckGlobalFlag 0x0047
+	CheckGlobalFlag GOMAN_RENTED_HOUSE
 	JumpIf script_08011CC2
 	EndBlock
 script_08011C9A:
@@ -26,9 +26,9 @@ script_08011C9A:
 script_08011CC2:
 	EndBlock
 	BeginBlock
-	CheckGlobalFlag 0x002c
+	CheckGlobalFlag RENTED_HOUSE_NAYRU
 	JumpIf script_08011C9A
-	CheckGlobalFlag 0x002d
+	CheckGlobalFlag RENTED_HOUSE_FARORE
 	JumpIf script_08011C9A
 	CheckEntityInteractType
 	JumpIfNot script_08011CC2
@@ -36,7 +36,7 @@ script_08011CC2:
 	SetPlayerIdle
 	FacePlayer
 	DoPostScriptAction 0x0000
-	MessageNoOverlap 0x3105
+	MessageNoOverlap2 TEXT_GORMAN_ORACLES, 0x5
 	WaitUntilTextboxCloses
 	CheckTextboxResult 
 	JumpIf script_08011D0E
@@ -51,9 +51,9 @@ script_08011D00:
 	FacePlayer
 	DoPostScriptAction 0x0000
 script_08011D0E:
-	MessageNoOverlap 0x3108
+	MessageNoOverlap2 TEXT_GORMAN_ORACLES, 0x8
 	WaitUntilTextboxCloses
-	SetGlobalFlag 0x002b
+	SetGlobalFlag RENTED_HOUSE_DIN
 	EnablePlayerControl
 	SetAnimationState 0x0004
 	DoPostScriptAction 0x0001

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -1,6 +1,9 @@
 #ifndef SPRITEDATA_H
 #define SPRITEDATA_H
 
+#include "gba/types.h"
+#include "entity.h"
+
 // Definition for enemies and projectiles
 typedef struct EnemyDefinition {
     u16 gfx;

--- a/include/droptables.h
+++ b/include/droptables.h
@@ -1,6 +1,8 @@
 #ifndef TMC_DROPTABLES_H
 #define TMC_DROPTABLES_H
 
+#include "global.h"
+
 typedef union {
     struct {
         s16 none;

--- a/include/hitbox.h
+++ b/include/hitbox.h
@@ -1,5 +1,8 @@
 #ifndef HITBOX_H
 #define HITBOX_H
+
+#include "entity.h"
+
 extern const Hitbox gHitbox_0;
 extern const Hitbox gHitbox_1;
 extern const Hitbox gHitbox_2;

--- a/include/kinstone.h
+++ b/include/kinstone.h
@@ -2,6 +2,7 @@
 #define KINSTONE_H
 
 #include "global.h"
+#include "entity.h"
 
 extern void sub_08018C58(u32);
 

--- a/include/projectile.h
+++ b/include/projectile.h
@@ -1,6 +1,8 @@
 #ifndef PROJECTILE_H
 #define PROJECTILE_H
 
+#include "entity.h"
+
 Entity* CreateProjectile(u32);
 bool32 IsProjectileOffScreen(Entity*);
 

--- a/tools/src/preproc/asm_file.cpp
+++ b/tools/src/preproc/asm_file.cpp
@@ -30,13 +30,12 @@
 AsmFile::AsmFile(std::string filename) : m_filename(filename) {
     FILE* fp = std::fopen(filename.c_str(), "rb");
 
-    if (fp == NULL) {
-        // The include might be an asset.
-        fp = std::fopen(("build/" + g_buildName + "/assets/" + filename).c_str(), "rb");
-
-        if (fp == NULL)
-            FATAL_ERROR("Failed to open \"%s\" for reading.\n", filename.c_str());
+    for (int i = 0; fp == NULL && i < g_incPaths.size(); i++) {
+        fp = std::fopen((g_incPaths[i] + "/" + filename).c_str(), "rb");
     }
+
+    if (fp == NULL)
+        FATAL_ERROR("Failed to open \"%s\" for reading.\n", filename.c_str());
 
     std::fseek(fp, 0, SEEK_END);
 

--- a/tools/src/preproc/preproc.cpp
+++ b/tools/src/preproc/preproc.cpp
@@ -19,7 +19,9 @@
 // THE SOFTWARE.
 
 #include <string>
+#include <cstring>
 #include <stack>
+#include <vector>
 #include "preproc.h"
 #include "asm_file.h"
 #include "c_file.h"
@@ -27,6 +29,7 @@
 
 Charmap* g_charmap;
 std::string g_buildName;
+std::vector<std::string> g_incPaths;
 
 void PrintAsmBytes(unsigned char* s, int length) {
     if (length > 0) {
@@ -117,13 +120,20 @@ char* GetFileExtension(char* filename) {
 }
 
 int main(int argc, char** argv) {
-    if (argc != 4 && argc != 3) {
-        std::fprintf(stderr, "Usage: %s BUILD_NAME SRC_FILE CHARMAP_FILE", argv[0]);
+    if (argc < 3) {
+        std::fprintf(stderr, "Usage: %s BUILD_NAME SRC_FILE [CHARMAP_FILE] -- [ASM INC PATH] ...", argv[0]);
         return 1;
     }
 
+    int pathStart = 0;
+    while (pathStart < argc && strcmp(argv[pathStart], "--") != 0) pathStart++;
+    
+    for (int i = pathStart + 1; i < argc; i++) {
+        g_incPaths.push_back(argv[i]);
+    }
+
     g_buildName = std::string(argv[1]);
-    g_charmap = new Charmap(argc == 4 ? argv[3] : "");
+    g_charmap = new Charmap(argc > 3 && pathStart > 3 ? argv[3] : "");
 
     char* extension = GetFileExtension(argv[2]);
 

--- a/tools/src/preproc/preproc.h
+++ b/tools/src/preproc/preproc.h
@@ -49,5 +49,6 @@ const unsigned long kMaxCharmapSequenceLength = 16;
 
 extern Charmap* g_charmap;
 extern std::string g_buildName;
+extern std::vector<std::string> g_incPaths;
 
 #endif // PREPROC_H


### PR DESCRIPTION
This pull request adds a script that extracts all enums from the include directory headers and creates asm macro files that the scripts can use.

A few things to note:
1. It uses python and pycparser. This probably means that the install readme and jenkins image need to be updated.
2. I've changed one script file to show off the change.

Opinions will be most welcome.