### PR TITLE
fix portablility issues

### DIFF
--- a/GBA.mk
+++ b/GBA.mk
@@ -123,7 +123,7 @@ $(BUILD_DIR)/%.o : %.c $$(deps)
 	@mkdir -p $(dir $@)
 	$(CPP) $(CPPFLAGS) $< -o $(BUILD_DIR)/$*.i
 	$(CC1) $(CFLAGS) -o $(BUILD_DIR)/$*.s $(BUILD_DIR)/$*.i
-	@echo "\t.text\n\t.align\t2, 0 @ Don't pad with nop\n" >> $(BUILD_DIR)/$*.s
+	@printf "\t.text\n\t.align\t2, 0 @ Don't pad with nop\n" >> $(BUILD_DIR)/$*.s
 	$(AS) $(ASFLAGS) -o $@ $(BUILD_DIR)/$*.s
 
 # ==============

--- a/GBA.mk
+++ b/GBA.mk
@@ -136,7 +136,7 @@ LIB := -L ../../tools/agbcc/lib -lc
 $(ROM): $(ELF)
 	$(OBJCOPY) -O binary --gap-fill 0xFF --pad-to 0x9000000 $< $@
 
-$(ELF): objs = $(shell grep -o -E "(\w|/)+\.o" linker.ld)
+$(ELF): objs = $(shell grep -vE "\*\w+\.a" linker.ld | grep -oE "(\w|/)+\.o")
 $(ELF): $(BUILD_DIR)/linker.ld $$(addprefix $(BUILD_DIR)/, $$(objs))
 	cd $(BUILD_DIR) && $(LD) $(LDFLAGS) -n -T linker.ld -o ../../$@ $(LIB)
 	$(FIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(REVISION) --silent

--- a/linker.ld
+++ b/linker.ld
@@ -867,7 +867,7 @@ SECTIONS {
         src/gba/m4a.o(.text);
         asm/lib/libagbsyscall.o(.text);
         src/eeprom.o(.text);
-        libc.a(.text);
+        *libc.a:memcpy.o(.text);
         /* handwritten assembly in arm mode */
         asm/src/intr.o(.text);
 


### PR DESCRIPTION
latest ld apparently does not like linking against `libc.a` instead of `*libc.a:memcpy.o`.
reverting that change and adjusting the dependency scanning in the linker file.
also use `printf` instead of `echo` because the should be more portable