### PR TITLE
Add Devcontainer configuration for easy development start

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,10 +1,12 @@
 FROM debian
 
 RUN apt update && apt upgrade && apt install -y --no-install-recommends \
+    ca-certificates \
     cmake \
     g++ \
     gcc \
     gcc-arm-none-eabi \
+    git \
     libpng-dev \
     make \
     python3 \

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -11,6 +11,7 @@ RUN apt update && apt upgrade && apt install -y --no-install-recommends \
     make \
     python3 \
     python3-pycparser \
+    ssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 ADD https://github.com/pret/agbcc.git /agbcc

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,21 @@
+FROM debian
+
+RUN apt update && apt upgrade && apt install -y --no-install-recommends \
+    cmake \
+    g++ \
+    gcc \
+    gcc-arm-none-eabi \
+    libpng-dev \
+    make \
+    python3 \
+    python3-pycparser \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD https://github.com/pret/agbcc.git /agbcc
+
+RUN cd /agbcc && \
+    ./build.sh && \
+    mkdir -p /agbcc-install && \
+    ./install.sh /agbcc-install
+
+ENV AGBCC_PATH=/agbcc-install/tools/agbcc

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,6 +1,6 @@
 FROM debian
 
-RUN apt update && apt upgrade && apt install -y --no-install-recommends \
+RUN apt update && apt upgrade -y && apt install -y --no-install-recommends \
     ca-certificates \
     cmake \
     g++ \

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -14,7 +14,7 @@ RUN apt update && apt upgrade && apt install -y --no-install-recommends \
     ssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-ADD https://github.com/pret/agbcc.git /agbcc
+RUN git clone https://github.com/pret/agbcc.git /agbcc
 
 RUN cd /agbcc && \
     ./build.sh && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "name": "zeldaret/tmc-dev",
+    "build": {
+        "dockerfile": "Containerfile"
+    }
+}

--- a/GBA.mk
+++ b/GBA.mk
@@ -95,7 +95,7 @@ $(BUILD_DIR)/%.o: %.s $$(deps) $(ENUM_ASM_HEADERS)
 
 $(BUILD_DIR)/enum_include/%.inc: include/%.h
 	@mkdir -p $(dir $@)
-	$(ENUM_PROCESSOR) $< $(CC) "-D__attribute__(x)=" "-D$(GAME_VERSION)" "-E" "-nostdinc" "-Itools/agbcc" "-Itools/agbcc/include" "-iquote include" > $@
+	$(ENUM_PROCESSOR) $< $(CC) "-D__attribute__(x)=" "-D$(GAME_VERSION)" "-E" "-nostdinc" "-I$(AGBCC_PATH)" "-I$(AGBCC_PATH)/include" "-iquote include" > $@
 
 # =============
 # build C files
@@ -103,7 +103,7 @@ $(BUILD_DIR)/enum_include/%.inc: include/%.h
 
 # agbcc includes are separate because we don't want dependency scanning on them
 CINCLUDE := -I include -I $(BUILD_DIR)
-CPPFLAGS := -I tools/agbcc -I tools/agbcc/include $(CINCLUDE) -nostdinc -undef -D$(GAME_VERSION) -DREVISION=$(REVISION) -D$(GAME_LANGUAGE)
+CPPFLAGS := -I $(AGBCC_PATH) -I $(AGBCC_PATH)/include $(CINCLUDE) -nostdinc -undef -D$(GAME_VERSION) -DREVISION=$(REVISION) -D$(GAME_LANGUAGE)
 CFLAGS := -O2 -Wimplicit -Wparentheses -Werror -Wno-multichar -g3
 
 interwork := $(BUILD_DIR)/src/interrupts.o \
@@ -131,7 +131,7 @@ $(BUILD_DIR)/%.o : %.c $$(deps)
 # ==============
 
 LDFLAGS = -Map ../../$(BUILD_DIR)/$(BUILD_NAME).map
-LIB := -L ../../tools/agbcc/lib -lc
+LIB := -L $(AGBCC_PATH)/lib -lc
 
 $(ROM): $(ELF)
 	$(OBJCOPY) -O binary --gap-fill 0xFF --pad-to 0x9000000 $< $@

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -28,7 +28,9 @@ OBJCOPY := $(TOOLCHAIN_PATH)arm-none-eabi-objcopy
 # custom tools
 # ============
 
-CC1 := tools/agbcc/bin/agbcc
+AGBCC_PATH ?= $(shell pwd)/tools/agbcc
+
+CC1 := $(AGBCC_PATH)/bin/agbcc
 SHA1 := $(shell { command -v sha1sum || command -v shasum; } 2>/dev/null) -c
 
 SCANINC := tools/bin/scaninc


### PR DESCRIPTION
This add a devcontainer configuration which allows for a very easy containerized setup.
The existing workflow shouldn't be affected noticably.
A `AGBCC_PATH` variable has been added to the Makefile to allow of an out of tree installation of `agbcc`.
It defaults to the old directory.

Still todo:
- [ ] update Install.md