### PR TITLE
fix libfmt compiler warnings with GCC 14

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -30,7 +30,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         fmt
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 8.0.1
+        GIT_TAG 11.0.2
 )
 # CLI11
 FetchContent_Declare(

--- a/tools/src/asset_processor/assets/frameobjlists.cpp
+++ b/tools/src/asset_processor/assets/frameobjlists.cpp
@@ -36,7 +36,12 @@ void FrameObjListsAsset::convertToHumanReadable(const std::vector<char>& baserom
         fmt::print(file.get(), "\t.4byte {:#x}\n", pointer);
     }
 
-    u32 max_second_level = *std::max_element(second_level.begin(), second_level.end());
+    auto max_second_level_it = std::max_element(second_level.begin(), second_level.end());
+    if (max_second_level_it == second_level.end()) {
+        fmt::print(stderr, "no second level (unreachable)");
+        exit(1);
+    }
+    u32 max_second_level = *max_second_level_it;
 
     while (reader.cursor < size) {
         if (static_cast<u32>(reader.cursor) > max_second_level) {


### PR DESCRIPTION
fixes #698 